### PR TITLE
fix coffee-script/register error when running test

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -59,7 +59,7 @@ runTests = (fileList) ->
 
         command = "#{env} #{command}"
         command += " #{fileList.join(" ")} "
-        command += " --reporter spec --require should --compilers coffee:coffee-script --colors"
+        command += " --reporter spec --require should --compilers coffee:coffee-script/register --colors"
         exec command, (err, stdout, stderr) ->
             console.log stdout
             if err


### PR DESCRIPTION
Hello,

Problem :
=======
When I ran test with the old file I had this error : 
```
Running mocha caught exception: 
Error: Command failed: 
/home/baremec/.node/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:210
          throw new Error("Use CoffeeScript.register() or require the coffee-s
                ^
Error: Use CoffeeScript.register() or require the coffee-script/register module to require .coffee.md files.
  at Object.base.(anonymous function) [as .coffee] (/home/baremec/.node/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:210:17)
```
Solution : 
======
I found a solution here : https://github.com/github/generator-hubot/pull/6
```
#test/mocha.opts
--compilers mocha --compilers coffee:coffee-script/register
```