### PR TITLE
Add build dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ results
 
 node_modules
 npm-debug.log
+
+build
+client/public

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ results
 node_modules
 npm-debug.log
 
-build
 client/public


### PR DESCRIPTION
Small improvement that allows to forget about deleting build directories before committing all files for example.